### PR TITLE
implement source address configuration

### DIFF
--- a/config.go
+++ b/config.go
@@ -11,13 +11,14 @@ import (
 
 // Config is a configuration file
 type Config struct {
-	AuthMethods map[string]*proxyclient.AuthMethod `yaml:"auth_methods"`
-	Proxies     []string                           `yaml:"proxies"`
-	Targets     []string                           `yaml:"targets"`
-	ListenPort  int                                `yaml:"listen_port,omitempty"`
-	Interval    int                                `yaml:"interval,omitempty"`
-	Insecure    bool                               `yaml:"insecure,omitempty"`
-	Debug       bool                               `yaml:"debug,omitempty"`
+	AuthMethods   map[string]*proxyclient.AuthMethod `yaml:"auth_methods"`
+	Proxies       []string                           `yaml:"proxies"`
+	Targets       []string                           `yaml:"targets"`
+	SourceAddress string                             `yaml:"source_address,omitempty"`
+	ListenPort    int                                `yaml:"listen_port,omitempty"`
+	Interval      int                                `yaml:"interval,omitempty"`
+	Insecure      bool                               `yaml:"insecure,omitempty"`
+	Debug         bool                               `yaml:"debug,omitempty"`
 }
 
 // loadConfig loads a configuration file and returns the corresponding struct pointer

--- a/main.go
+++ b/main.go
@@ -140,7 +140,15 @@ func main() {
 					} else {
 						firstMeasurement = false
 					}
-					preq, err := proxyclient.MakeClientAndRequest(target, proxy, auth, config.Insecure)
+
+					requestConfig := proxyclient.RequestConfig{
+						Target:     target,
+						Proxy:      proxy,
+						Auth:       auth,
+						SourceAddr: config.SourceAddress,
+						Insecure:   config.Insecure,
+					}
+					preq, err := proxyclient.MakeClientAndRequest(requestConfig)
 					if err != nil {
 						log.Errorf("error while preparing request: %s", err)
 					}


### PR DESCRIPTION
Add the ability to configure the source IP address used for probing.
This commit introduces a breaking change on softs relying on
`proxyclient.MakeClientAndRequest()`: in order to easier future changes
and reduce the number of arguments, the function now takes a struct as
input.