### PR TITLE
disable idle connections

### DIFF
--- a/proxyclient/proxyclient.go
+++ b/proxyclient/proxyclient.go
@@ -65,6 +65,8 @@ func proxifiedTransport(proxyURL *url.URL, sourceAddr string, insecure bool) (*h
 			LocalAddr: &localTCPAddr,
 			DualStack: true,
 		}).DialContext,
+		MaxIdleConnsPerHost: 1,
+		DisableKeepAlives:   true,
 	}
 	return tr, nil
 }


### PR DESCRIPTION
Avoid keeping idle connections by setting the maximum of idle connections per host and disabling
keepalives. Since the proxyclient is supposed to be used with software
testing proxies, we do not need to keep connections alive to allow
reuse.