### PR TITLE
implement new metric for individual requests duration

### DIFF
--- a/main.go
+++ b/main.go
@@ -55,8 +55,8 @@ var (
 	}, []string{"proxy_url", "resource_url"})
 
 	proxyRequestDurations = prometheus.NewGaugeVec(prometheus.GaugeOpts{
-		Name: "proxy_request_time_seconds",
-		Help: "Gauge of durations for each request",
+		Name: "proxy_request_rtt_seconds",
+		Help: "Gauge of round trip time for each request",
 	}, []string{"proxy_url", "resource_url"})
 
 	proxyRequestsDurations = prometheus.NewHistogramVec(prometheus.HistogramOpts{

--- a/main.go
+++ b/main.go
@@ -54,9 +54,14 @@ var (
 		Help: "Number of failed requests.",
 	}, []string{"proxy_url", "resource_url"})
 
+	proxyRequestDurations = prometheus.NewGaugeVec(prometheus.GaugeOpts{
+		Name: "proxy_request_time_seconds",
+		Help: "Gauge of durations for each request",
+	}, []string{"proxy_url", "resource_url"})
+
 	proxyRequestsDurations = prometheus.NewHistogramVec(prometheus.HistogramOpts{
 		Name: "proxy_requests_time_seconds",
-		Help: "Duration of requests.",
+		Help: "Histogram of requests durations.",
 	}, []string{"proxy_url", "resource_url"})
 )
 
@@ -74,6 +79,7 @@ func init() {
 	prometheus.MustRegister(proxyRequests)
 	prometheus.MustRegister(proxyRequestsSuccesses)
 	prometheus.MustRegister(proxyRequestsFailures)
+	prometheus.MustRegister(proxyRequestDurations)
 	prometheus.MustRegister(proxyRequestsDurations)
 }
 
@@ -186,6 +192,7 @@ func main() {
 					proxyConnectionSuccesses.WithLabelValues(proxy).Inc()
 					proxyRequests.WithLabelValues(proxy, target).Inc()
 					proxyRequestsSuccesses.WithLabelValues(proxy, target).Inc()
+					proxyRequestDurations.WithLabelValues(proxy, target).Set(duration)
 					proxyRequestsDurations.WithLabelValues(proxy, target).Observe(duration)
 				}
 			}(target, proxy)


### PR DESCRIPTION
Add a metric to measure actual latency of every requests. This new
metric will help troubleshooting and investigations as it shows the
evolution of requests duration over time.
Note that this new metric's name `proxy_request_time_seconds` is very
similar to `proxy_requests_time_seconds` but they are not exactly the
same. You can always refer to the Prometheus help in the code for more details.