### PR TITLE
remove legacy metric

### DIFF
--- a/main.go
+++ b/main.go
@@ -63,10 +63,6 @@ var (
 		Name: "proxy_requests_rtt_seconds",
 		Help: "Histogram of requests durations.",
 	}, []string{"proxy_url", "resource_url"})
-	proxyRequestsDurationsLegacy = prometheus.NewHistogramVec(prometheus.HistogramOpts{
-		Name: "proxy_requests_time_seconds",
-		Help: "Histogram of requests durations.",
-	}, []string{"proxy_url", "resource_url"})
 )
 
 func init() {
@@ -85,7 +81,6 @@ func init() {
 	prometheus.MustRegister(proxyRequestsFailures)
 	prometheus.MustRegister(proxyRequestDurations)
 	prometheus.MustRegister(proxyRequestsDurations)
-	prometheus.MustRegister(proxyRequestsDurationsLegacy)
 }
 
 func main() {
@@ -199,7 +194,6 @@ func main() {
 					proxyRequestsSuccesses.WithLabelValues(proxy, target).Inc()
 					proxyRequestDurations.WithLabelValues(proxy, target).Set(duration)
 					proxyRequestsDurations.WithLabelValues(proxy, target).Observe(duration)
-					proxyRequestsDurationsLegacy.WithLabelValues(proxy, target).Observe(duration)
 				}
 			}(target, proxy)
 		}


### PR DESCRIPTION
As stated in (#7), the `proxy_requests_time_seconds` is now replaced by
`proxy_requests_rtt_seconds`.