### PR TITLE
implement per target insecure

### DIFF
--- a/config.example.yml
+++ b/config.example.yml
@@ -8,4 +8,4 @@ proxies:
   - "http://my-http-proxy:8080/"
   - "https//my-https-proxy:8443/"
 targets:
-  - "https://www.example.com/"
+  - url: "https://www.example.com/"

--- a/config.go
+++ b/config.go
@@ -13,12 +13,17 @@ import (
 type Config struct {
 	AuthMethods   map[string]*proxyclient.AuthMethod `yaml:"auth_methods,omitempty"`
 	Proxies       []string                           `yaml:"proxies"`
-	Targets       []string                           `yaml:"targets"`
+	Targets       []Target                           `yaml:"targets"`
 	SourceAddress string                             `yaml:"source_address,omitempty"`
 	ListenPort    int                                `yaml:"listen_port,omitempty"`
 	Interval      int                                `yaml:"interval,omitempty"`
-	Insecure      bool                               `yaml:"insecure,omitempty"`
 	Debug         bool                               `yaml:"debug,omitempty"`
+}
+
+// Target is a HTTP(S) service that will be probed
+type Target struct {
+	URL      string `yaml:"url"`
+	Insecure bool   `yaml:"insecure,omitempty"`
 }
 
 // loadConfig loads a configuration file and returns the corresponding struct pointer

--- a/config_test.go
+++ b/config_test.go
@@ -18,6 +18,7 @@ func TestLoadConfig(t *testing.T) {
 }
 
 func TestVerifyConfig(t *testing.T) {
+	var targets []Target
 	var errs []error
 
 	proxies := []string{
@@ -33,7 +34,11 @@ func TestVerifyConfig(t *testing.T) {
 		},
 	}
 
-	targets := []string{"https://www.example.com"}
+	target := Target{
+		URL: "https://www.example.com/",
+	}
+
+	targets = append(targets, target)
 
 	config := Config{
 		AuthMethods: map[string]*proxyclient.AuthMethod{
@@ -52,7 +57,7 @@ func TestVerifyConfig(t *testing.T) {
 	assert.Len(t, errs, 1)
 
 	noTargets := config
-	noTargets.Targets = []string{}
+	noTargets.Targets = []Target{}
 	errs = verifyConfig(&noTargets)
 	assert.Len(t, errs, 1)
 


### PR DESCRIPTION
Be more precise when activating insecure mode by moving from a global
configuration to a per-target configuration.
Note that this is a breaking change since targets are now an array of targets
instead of an array of strings.