### PR TITLE
implement "high precision" mode

### DIFF
--- a/config.go
+++ b/config.go
@@ -17,6 +17,7 @@ type Config struct {
 	SourceAddress string                             `yaml:"source_address,omitempty"`
 	ListenPort    int                                `yaml:"listen_port,omitempty"`
 	Interval      int                                `yaml:"interval,omitempty"`
+	HighPrecision bool                               `yaml:"high_precision,omitempty"`
 	Debug         bool                               `yaml:"debug,omitempty"`
 }
 


### PR DESCRIPTION
This mode is intended if you are interested in probes with relatively low
latencies (<50-100ms): histogram buckets are much better for this range
of latencies.