### PR TITLE
Properly handle credentials in proxy URL

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,6 +1,6 @@
 language: go
 go:
-  - 1.14.x
+  - 1.15.x
 env:
   - GO111MODULE=on
 script:

--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module github.com/criteo/http-proxy-exporter
 
-go 1.14
+go 1.15
 
 require (
 	github.com/prometheus/client_golang v1.5.1


### PR DESCRIPTION
This allows to specify per-proxy credentials. The error handling is also
reworked to properly handle credentials errors