### PR TITLE
Clean proxy_url in metrics

### DIFF
--- a/measure_test.go
+++ b/measure_test.go
@@ -182,8 +182,9 @@ func TestProxyOKAuth(t *testing.T) {
 
 	u, _ := url.Parse(proxyURL)
 	u.User = url.UserPassword("user", "secret_pass")
-	proxyURLMetrics := u.Redacted()
 	proxyURL = u.String()
+	u.User = nil
+	proxyURLMetrics := u.String()
 
 	measureOne(proxyURL, Target{URL: originURL, Insecure: true}, &proxyclient.AuthMethod{})
 


### PR DESCRIPTION
Since the last patch, metrics used resolved url which caused issues
since it didn't match the config values. The user information is also
removed